### PR TITLE
Fix crash on boot

### DIFF
--- a/app/src/main/java/collegeproject/askme_bot/MainActivity.java
+++ b/app/src/main/java/collegeproject/askme_bot/MainActivity.java
@@ -45,15 +45,48 @@ public class MainActivity extends AppCompatActivity {
     @Inject @Named("shubham")
     Retrofit retrofit2;
 
+    //These are the only permissions defined as dangerous in the manifest
+    //Internet and access current state aren't dangerous
+    final String[] perms = {Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.RECORD_AUDIO};
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M){
+            //Permission requesting only applies to Android M (API 23) and above
+            checkPermissions();
+        }
         setContentView(R.layout.activity_main);
         Intent intent = new Intent(MainActivity.this,FirstActivity.class);
         startActivity(intent);
     }
+
+    public void checkPermissions(){
+        if(!granted(perms)) {
+            Log.i("Permissions", "Missing permissions. Requesting...");
+            ActivityCompat.requestPermissions(this, perms, 101);
+        }else{
+            Log.i("Permissions", "All permissions granted!");
+        }
+    }
+
+    private boolean granted(String[] permissions) {
+        for(String s : permissions) {
+            int result = ContextCompat.checkSelfPermission(this, s);
+            if (result != PackageManager.PERMISSION_GRANTED) {
+                // If the permission isn't granted, just return false. The permission requesting system doesn't
+                // request already granted permissions, so this
+                // also works as a shortcut
+                return false;
+            }
+        }
+        return true;
+    }
 }
+
 


### PR DESCRIPTION
Forked the repo, ran it on my device and got this error:

```
FATAL EXCEPTION: main
Process: collegeproject.askme_bot, PID: 19867
    java.lang.SecurityException: my location requires permission ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION
    at com.google.maps.api.android.lib6.impl.ba.c(:com.google.android.gms.DynamiteModulesB@11518440:689)
    at com.google.android.gms.maps.internal.k.onTransact(:com.google.android.gms.DynamiteModulesB@11518440:141)
    at android.os.Binder.transact(Binder.java:507)
    at com.google.android.gms.maps.internal.IGoogleMapDelegate$zza$zza.setMyLocationEnabled(Unknown Source)
    at com.google.android.gms.maps.GoogleMap.setMyLocationEnabled(Unknown Source)
    at collegeproject.askme_bot.Navigation$1$1$1.onMapReady(Navigation.java:66)
    at com.google.android.gms.maps.MapView$zza$1.zza(Unknown Source)
    at com.google.android.gms.maps.internal.zzl$zza.onTransact(Unknown Source)
    at android.os.Binder.transact(Binder.java:507)
    at gl.b(:com.google.android.gms.DynamiteModulesB@11518440:20)
    at com.google.android.gms.maps.internal.bf.a(:com.google.android.gms.DynamiteModulesB@11518440:5)
    at com.google.maps.api.android.lib6.impl.bc.run(:com.google.android.gms.DynamiteModulesB@11518440:5)
    at android.os.Handler.handleCallback(Handler.java:751)
    at android.os.Handler.dispatchMessage(Handler.java:95)
    at android.os.Looper.loop(Looper.java:154)
    at android.app.ActivityThread.main(ActivityThread.java:6682)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1520)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1410)
```

That is only related to one permission, but it applies to three of them total

API 23 introduced permission requesting which this app didn't add (you target API 23 so you have to add it).  You can read more about it [here](https://developer.android.com/training/permissions/requesting.html) . All the dangerous permissions have to be requested, and which are which is listed in the [permission docs](https://developer.android.com/reference/android/Manifest.permission.html#ACCESS_COARSE_LOCATION). That link is directly to `ACCESS_COARSE_LOCATION` as that's one permission you have, but **all** the Android permissions are listed there.



What this pull request does:

Closes #1 

Requests permissions in API 23 and above. 

Adds a system for adding other permissions later.


